### PR TITLE
Fix unescaped { } ( RT#114385)

### DIFF
--- a/t/ppi.t
+++ b/t/ppi.t
@@ -120,7 +120,7 @@ throws_ok {
 
 throws_ok {
   Parse::Method::Signatures->new(':foo( {$x, :@y])')->param(),
-} qr/^Runaway '{}' in unpacked parameter near '{\$x, :\@y' at /,
+} qr/^Runaway '\{\}' in unpacked parameter near '\{\$x, :\@y' at /,
   q/Runaway '{}' in unpacked parameter near '{$x, :@y' at /;
 
 test_param(


### PR DESCRIPTION
{ in QR now needs escaping.